### PR TITLE
Add prefix_fuzzy_search function.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuzzy_trie"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["VictorBulba"]
 edition = "2018"
 license = "MIT"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,23 @@ impl<T> FuzzyTrie<T> {
     }
 
 
+    /// Makes fuzzy search on prefix with given key and puts result to out collector
+    /// See `Collector` for additional information
+    #[inline]
+    pub fn prefix_fuzzy_search<'a, C: Collector<'a, T>>(&'a self, key: &str, out: &mut C) {
+        let branches = match &self.root {
+            Node::Branch(_, branches) => branches,
+            _ => unreachable!(),
+        };
+        let dfa = self
+            .choose_dfa_builder(key.chars().count())
+            .build_prefix_dfa(key);
+        for br in branches {
+            br.fuzzy_search(&self.values, &dfa, dfa.initial_state(), out);
+        }
+    }
+
+
     /// Iterator over values
     #[inline]
     pub fn iter(&self) -> Iter<'_, T> {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,18 @@
 use crate::FuzzyTrie;
 use crate::Config;
 use crate::LevenshteinConfig;
+use std::fmt::Debug;
+
+
+fn test_search<'a, T>(trie: &FuzzyTrie<T>, key: &str, expected_values: Vec<T>)
+where
+    T: Copy + Ord + Debug,
+{
+    let mut values: Vec<T> = Vec::new();
+    trie.prefix_fuzzy_search(key, &mut values);
+    values.sort();
+    assert_eq!(values, expected_values);
+}
 
 
 #[test]
@@ -52,4 +64,48 @@ fn test_custom_config() {
     assert_eq!(Some(40), hello_iter.next());
     assert_eq!(Some(45), hello_iter.next());
     assert_eq!(None, hello_iter.next());
+}
+
+
+#[test]
+fn test_prefix() {
+    let mut trie = FuzzyTrie::new(2, false);
+    trie.insert("something").insert(1);
+    trie.insert("something").insert(2);
+    trie.insert("something else").insert(3);
+    trie.insert("somewhere").insert(4);
+    trie.insert("some time").insert(5);
+    trie.insert("sometimes").insert(6);
+
+    test_search(&trie, "s0me", vec![1, 2, 3, 4, 5, 6]);
+    test_search(&trie, "s0ma", vec![1, 2, 3, 4, 5, 6]);
+    test_search(&trie, "s0meth", vec![1, 2, 3, 4, 6]);
+    test_search(&trie, "s0methin", vec![1, 2, 3]);
+    test_search(&trie, "somatime", vec![5, 6]);
+    test_search(&trie, "something wrong", vec![]);
+}
+
+
+#[test]
+fn test_prefix_with_custom_config() {
+    let default = LevenshteinConfig {distance: 2, damerau: false};
+    let len4 = LevenshteinConfig {distance: 1, damerau: false};
+    let len3 = LevenshteinConfig {distance: 0, damerau: false};
+    let config = Config {default, other: vec![(len3, 3), (len4, 4)]};
+    let mut trie = FuzzyTrie::new_with_config(&config);
+
+    trie.insert("something").insert(1);
+    trie.insert("something").insert(2);
+    trie.insert("something else").insert(3);
+    trie.insert("somewhere").insert(4);
+    trie.insert("some time").insert(5);
+    trie.insert("sometimes").insert(6);
+
+    test_search(&trie, "s0me", vec![1, 2, 3, 4, 5, 6]);
+    test_search(&trie, "s0ma", vec![]);
+    test_search(&trie, "s0m", vec![]);
+    test_search(&trie, "s0meth", vec![1, 2, 3, 4, 6]);
+    test_search(&trie, "s0methin", vec![1, 2, 3]);
+    test_search(&trie, "somatime", vec![5, 6]);
+    test_search(&trie, "something wrong", vec![]);
 }


### PR DESCRIPTION
Try to support the prefix_fuzzy search.
The change is small, just use the [build_prefix_dfa](https://docs.rs/levenshtein_automata/0.2.1/levenshtein_automata/struct.LevenshteinAutomatonBuilder.html#method.build_prefix_dfa) function in the [levenshtein_automata](https://crates.io/crates/levenshtein_automata) crate. Should not affect existing functionality.